### PR TITLE
Removes zero length bug

### DIFF
--- a/hashids.go
+++ b/hashids.go
@@ -153,7 +153,7 @@ func decode(hash, alphabetOriginal, salt, seps, guards []rune) []int {
 	if len(hashes) == 2 || len(hashes) == 3 {
 		hashIndex = 1
 	} else {
-		panic("malformed hash input")
+		hashIndex = 0
 	}
 
 	hashes = splitRunes(hashes[hashIndex], seps)
@@ -200,6 +200,7 @@ func getSepsAndGuards(alphabet []rune) ([]rune, []rune, []rune) {
 	}
 	return alphabet, seps, guards
 }
+
 
 func splitRunes(input, seps []rune) [][]rune {
 	splitIndices := make([]int, 0)

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -25,3 +25,24 @@ func TestEncryptDecrypt(t *testing.T) {
 		}
 	}
 }
+
+func TestZeroMinimumLength(t *testing.T) {
+	hid := New()
+	hid.Salt = "this is my salt"
+
+	numbers := []int{45, 434, 1313, 99}
+	hash := hid.Encrypt(numbers)
+	dec := hid.Decrypt(hash)
+
+	t.Logf("%v -> %v -> %v", numbers, hash, dec)
+
+	if len(numbers) != len(dec) {
+		t.Error("lengths do not match")
+	}
+
+	for i, n := range numbers {
+		if n != dec[i] {
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
It wasn't possible to set the minimum length to zero (which according to hashids.org should result in the smallest possible hash).
Now it is possible. While I can't say I understand the algorithm completely, I've studied both the JS and Ruby versions and the implementations regarding the `decode` function are now the same.
