### PR TITLE
Throw errors instead of panicing

### DIFF
--- a/hashids.go
+++ b/hashids.go
@@ -8,6 +8,7 @@ package hashids
 
 import (
 	"bytes"
+	"errors"
 	"math"
 	"strconv"
 )
@@ -30,17 +31,17 @@ func New() *HashID {
 
 // Encrypt hashes an array of int to a string containing at least MinLength characters taken from the Alphabet.
 // Use Decrypt using the same Alphabet and Salt to get back the array of int.
-func (h *HashID) Encrypt(numbers []int) string {
+func (h *HashID) Encrypt(numbers []int) (string, error) {
 	if len(numbers) == 0 {
-		panic("encrypting empty array of numbers makes no sense")
+		return "", errors.New("encrypting empty array of numbers makes no sense")
 	}
 	for _, n := range numbers {
 		if n < 0 {
-			panic("negative number not supported")
+			return "", errors.New("negative number not supported")
 		}
 	}
 	if len(h.Alphabet) < 4 {
-		panic("alphabet must contain at least 4 characters")
+		return "", errors.New("alphabet must contain at least 4 characters")
 	}
 
 	alphabetRunes := []rune(h.Alphabet)
@@ -50,7 +51,7 @@ func (h *HashID) Encrypt(numbers []int) string {
 
 	alphabetRunes = consistentShuffle(alphabetRunes, saltRunes)
 
-	return string(encode(numbers, alphabetRunes, saltRunes, seps, guards, h.MinLength))
+	return string(encode(numbers, alphabetRunes, saltRunes, seps, guards, h.MinLength)), nil
 }
 
 func encode(numbers []int, alphabetOriginal, salt, sepsOriginal, guards []rune, minLength int) []rune {
@@ -200,7 +201,6 @@ func getSepsAndGuards(alphabet []rune) ([]rune, []rune, []rune) {
 	}
 	return alphabet, seps, guards
 }
-
 
 func splitRunes(input, seps []rune) [][]rune {
 	splitIndices := make([]int, 0)

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -10,7 +10,10 @@ func TestEncryptDecrypt(t *testing.T) {
 	hid.Salt = "this is my salt"
 
 	numbers := []int{45, 434, 1313, 99}
-	hash := hid.Encrypt(numbers)
+	hash, err := hid.Encrypt(numbers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dec := hid.Decrypt(hash)
 
 	t.Logf("%v -> %v -> %v", numbers, hash, dec)
@@ -31,7 +34,10 @@ func TestZeroMinimumLength(t *testing.T) {
 	hid.Salt = "this is my salt"
 
 	numbers := []int{45, 434, 1313, 99}
-	hash := hid.Encrypt(numbers)
+	hash, err := hid.Encrypt(numbers)
+	if err != nil {
+		t.Fatal(err)
+	}
 	dec := hid.Decrypt(hash)
 
 	t.Logf("%v -> %v -> %v", numbers, hash, dec)


### PR DESCRIPTION
Changed all the panics in the Encrypt method to returning errors
instead. Also updated the tests for this change. This pull request
(mostly) fixes issue #2.

There is still one panic left in the package in the unhash function.
Perhaps this should be changed to returning an error as well.
