### PR TITLE
Fix offset panic with smaller results than minLength

### DIFF
--- a/hashids.go
+++ b/hashids.go
@@ -169,7 +169,7 @@ func (h *HashID) Encode(numbers []int) (string, error) {
 		result = append([]rune{h.guards[guardIndex]}, result...)
 
 		if len(result) < h.minLength {
-			guardIndex = (numbersHash + int(result[2])) % len(h.guards)
+			guardIndex = (numbersHash + int(result[1])) % len(h.guards)
 			result = append(result, h.guards[guardIndex])
 		}
 	}


### PR DESCRIPTION
Running the following code you end up with an `index out of range` panic:

``` go
package main

import hashids "github.com/speps/go-hashids"

func main() {
    hd := hashids.NewData()
    hd.Salt = "salt1"
    hd.MinLength = 10
    h := hashids.NewWithData(hd)
    h.Encode([]int{0})
}
```

``` text
panic: runtime error: index out of range

goroutine 16 [running]:
runtime.panic(0x311a0, 0x5e67c)
    /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/panic.c:279 +0xf5
github.com/speps/go-hashids.(*HashID).Encode(0x2080b6000, 0x2208239ef8, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0)
    /Volumes/CaseSensitive/go/src/github.com/speps/go-hashids/hashids.go:172 +0x11fa
main.main()
    /private/tmp/hashids.go:14 +0xd5

goroutine 17 [runnable]:
runtime.MHeap_Scavenger()
    /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/mheap.c:507
runtime.goexit()
    /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/proc.c:1445

goroutine 18 [runnable]:
bgsweep()
    /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/mgc0.c:1976
runtime.goexit()
    /usr/local/Cellar/go/1.3.1/libexec/src/pkg/runtime/proc.c:1445
```

As far as I can tell, when the second guard character is appended to the result an index offset larger than the length of result is used. Might be worth adding a regression test for this as well.

Thanks,
Adrian
