### PR TITLE
Use int64 instead of int for numbers.

### DIFF
--- a/hashids_test.go
+++ b/hashids_test.go
@@ -1,6 +1,7 @@
 package hashids
 
 import (
+	"math"
 	"testing"
 )
 
@@ -17,6 +18,33 @@ func TestEncryptDecrypt(t *testing.T) {
 		t.Fatal(err)
 	}
 	dec := hid.Decode(hash)
+
+	t.Logf("%v -> %v -> %v", numbers, hash, dec)
+
+	if len(numbers) != len(dec) {
+		t.Error("lengths do not match")
+	}
+
+	for i, n := range numbers {
+		if n != dec[i] {
+			t.Fail()
+		}
+	}
+}
+
+func TestEncryptDecryptInt64(t *testing.T) {
+	hdata := NewData()
+	hdata.MinLength = 30
+	hdata.Salt = "this is my salt"
+
+	hid := NewWithData(hdata)
+
+	numbers := []int64{45, 434, 1313, 99, math.MaxInt64}
+	hash, err := hid.EncodeInt64(numbers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := hid.DecodeInt64(hash)
 
 	t.Logf("%v -> %v -> %v", numbers, hash, dec)
 


### PR DESCRIPTION
Currently it's impossible to safely Encode/Decode int64 IDs unless all involved systems run on a 64bit machine where `int` data type is 64-bit. Hashids libraries in other languages (checked C#, JS) seem to support 64bit IDs.

This PR changes the `[]int` to `[]int64` everywhere. All tests pass. However, since it changes the signature of the Encode/Decode functions all users of this library have to migrate their code manually.