### PR TITLE
Fixed example readme to include returned error from Encode()

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ func main() {
     hd.Salt = "this is my salt"
     hd.MinLength = 30
     h := hashids.NewWithData(hd)
-    e := h.Encode([]int{45, 434, 1313, 99})
+    e, _ := h.Encode([]int{45, 434, 1313, 99})
     fmt.Println(e)
     d := h.Decode(e)
     fmt.Println(d)


### PR DESCRIPTION
An error is returned by Encode() and in the current example, it is throwing an error as it is not caught.