### PR TITLE
Renamed Encrypt/Decrypt to Encode/Decode on tests and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,28 +31,28 @@ func main() {
 ### Test results
 
 ```
-=== RUN   TestEncryptDecrypt
---- PASS: TestEncryptDecrypt (0.00s)
-        hashids_test.go:22: [45 434 1313 99] -> woQ2vqjnG7nnhzEsDkiYadKa3O71br -> [45 434 1313 99]
-=== RUN   TestEncryptDecryptInt64
---- PASS: TestEncryptDecryptInt64 (0.00s)
-        hashids_test.go:49: [45 434 1313 99 9223372036854775807] -> ZvGlaahBptQNfPOuPjJ51zO3wVzP01 -> [45 434 1313 99 9223372036854775807]
-=== RUN   TestEncryptWithKnownHash
---- PASS: TestEncryptWithKnownHash (0.00s)
-        hashids_test.go:75: [45 434 1313 99] -> 7nnhzEsDkiYa
-=== RUN   TestDecryptWithKnownHash
---- PASS: TestDecryptWithKnownHash (0.00s)
-        hashids_test.go:92: 7nnhzEsDkiYa -> [45 434 1313 99]
+=== RUN   TestEncodeDecode
+--- PASS: TestEncodeDecode (0.00s)
+	hashids_test.go:22: [45 434 1313 99] -> woQ2vqjnG7nnhzEsDkiYadKa3O71br -> [45 434 1313 99]
+=== RUN   TestEncodeDecodeInt64
+--- PASS: TestEncodeDecodeInt64 (0.00s)
+	hashids_test.go:49: [45 434 1313 99 9223372036854775807] -> ZvGlaahBptQNfPOuPjJ51zO3wVzP01 -> [45 434 1313 99 9223372036854775807]
+=== RUN   TestEncodeWithKnownHash
+--- PASS: TestEncodeWithKnownHash (0.00s)
+	hashids_test.go:75: [45 434 1313 99] -> 7nnhzEsDkiYa
+=== RUN   TestDecodeWithKnownHash
+--- PASS: TestDecodeWithKnownHash (0.00s)
+	hashids_test.go:92: 7nnhzEsDkiYa -> [45 434 1313 99]
 === RUN   TestDefaultLength
 --- PASS: TestDefaultLength (0.00s)
-        hashids_test.go:115: [45 434 1313 99] -> 7nnhzEsDkiYa -> [45 434 1313 99]
+	hashids_test.go:115: [45 434 1313 99] -> 7nnhzEsDkiYa -> [45 434 1313 99]
 === RUN   TestMinLength
 --- PASS: TestMinLength (0.00s)
 === RUN   TestCustomAlphabet
 --- PASS: TestCustomAlphabet (0.00s)
-        hashids_test.go:150: [45 434 1313 99] -> MAkhkloFAxAoskax -> [45 434 1313 99]
-=== RUN   TestDecryptWithError
---- PASS: TestDecryptWithError (0.00s)
+	hashids_test.go:150: [45 434 1313 99] -> MAkhkloFAxAoskax -> [45 434 1313 99]
+=== RUN   TestDecodeWithError
+--- PASS: TestDecodeWithError (0.00s)
 PASS
 ```
 

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestEncryptDecrypt(t *testing.T) {
+func TestEncodeDecode(t *testing.T) {
 	hdata := NewData()
 	hdata.MinLength = 30
 	hdata.Salt = "this is my salt"
@@ -32,7 +32,7 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 }
 
-func TestEncryptDecryptInt64(t *testing.T) {
+func TestEncodeDecodeInt64(t *testing.T) {
 	hdata := NewData()
 	hdata.MinLength = 30
 	hdata.Salt = "this is my salt"
@@ -59,7 +59,7 @@ func TestEncryptDecryptInt64(t *testing.T) {
 	}
 }
 
-func TestEncryptWithKnownHash(t *testing.T) {
+func TestEncodeWithKnownHash(t *testing.T) {
 	hdata := NewData()
 	hdata.MinLength = 0
 	hdata.Salt = "this is my salt"
@@ -79,7 +79,7 @@ func TestEncryptWithKnownHash(t *testing.T) {
 	}
 }
 
-func TestDecryptWithKnownHash(t *testing.T) {
+func TestDecodeWithKnownHash(t *testing.T) {
 	hdata := NewData()
 	hdata.MinLength = 0
 	hdata.Salt = "this is my salt"
@@ -160,7 +160,7 @@ func TestCustomAlphabet(t *testing.T) {
 	}
 }
 
-func TestDecryptWithError(t *testing.T) {
+func TestDecodeWithError(t *testing.T) {
 	hdata := NewData()
 	hdata.Alphabet = "PleasAkMEFoThStx"
 	hdata.Salt = "this is my salt"
@@ -170,9 +170,9 @@ func TestDecryptWithError(t *testing.T) {
 	dec, err := hid.DecodeWithError("MAkhkloFAxAoskaZ")
 
 	if dec != nil {
-		t.Error("DecryptWithError should have returned nil result")
+		t.Error("DecodeWithError should have returned nil result")
 	}
 	if err == nil {
-		t.Error("DecryptWithError should have returned error")
+		t.Error("DecodeWithError should have returned error")
 	}
 }


### PR DESCRIPTION
To be consistent with the names on `hashids.go`