### PR TITLE
improve test parity with hashid.js

### DIFF
--- a/hashids_bad_input_test.go
+++ b/hashids_bad_input_test.go
@@ -62,9 +62,9 @@ func TestNegativeNumberWithEncode(t *testing.T) {
 
 func TestEmptySliceWithDecode(t *testing.T) {
 	h := New()
-	v, err := h.Encode([]int{})
+	v, err := h.DecodeWithError("")
 
-	if v != "" {
+	if len(v) != 0 {
 		t.Errorf("Expected empty string and got `%s`", v)
 	}
 	if err != nil {

--- a/hashids_bad_input_test.go
+++ b/hashids_bad_input_test.go
@@ -1,0 +1,73 @@
+package hashids
+
+import "testing"
+
+func TestSmallAlphabet(t *testing.T) {
+	hdata := NewData()
+	hdata.Alphabet = "1234567890"
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected an error as alphabet was too small")
+		}
+	}()
+	NewWithData(hdata)
+}
+
+func TestSpacesInAlphabet(t *testing.T) {
+	hdata := NewData()
+	hdata.Alphabet = "a cdefghijklmnopqrstuvwxyz"
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected an error as spaces in alphabet are not allowed")
+		}
+	}()
+	NewWithData(hdata)
+}
+
+func TestNilWithEncode(t *testing.T) {
+	h := New()
+	v, err := h.Encode(nil)
+
+	if v != "" {
+		t.Errorf("Expected empty string and got `%s`", v)
+	}
+	if err != nil {
+		t.Errorf("Expected empty slice and got error `%s`", err)
+	}
+}
+
+func TestEmptySliceWithEncode(t *testing.T) {
+	h := New()
+	v, err := h.Encode([]int{})
+
+	if v != "" {
+		t.Errorf("Expected empty string and got `%s`", v)
+	}
+	if err != nil {
+		t.Errorf("Expected empty slice and got error `%s`", err)
+	}
+}
+
+func TestNegativeNumberWithEncode(t *testing.T) {
+	h := New()
+	v, err := h.Encode([]int{-1})
+
+	if v != "" {
+		t.Errorf("Expected empty string and got `%s`", v)
+	}
+	if err != nil {
+		t.Errorf("Expected empty string and got error `%s`", err)
+	}
+}
+
+func TestEmptySliceWithDecode(t *testing.T) {
+	h := New()
+	v, err := h.Encode([]int{})
+
+	if v != "" {
+		t.Errorf("Expected empty string and got `%s`", v)
+	}
+	if err != nil {
+		t.Errorf("Expected empty slice and got error `%s`", err)
+	}
+}

--- a/hashids_custom_alphabet_test.go
+++ b/hashids_custom_alphabet_test.go
@@ -1,0 +1,47 @@
+package hashids
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testAlphabet(alphabet string, t *testing.T) {
+	numbers := []int{1, 2, 3}
+	hdata := NewData()
+	hdata.Alphabet = alphabet
+	h := NewWithData(hdata)
+	e, err := h.Encode(numbers)
+	decodedNumbers := h.Decode(e)
+
+	if err != nil {
+		t.Errorf("Expected no error but got `%s`", err)
+	}
+
+	if !reflect.DeepEqual(decodedNumbers, numbers) {
+		t.Errorf("Decoded numbers `%b` did not match with original `%b`", decodedNumbers, numbers)
+	}
+}
+
+func TestShouldWorkWithWorst(t *testing.T) {
+	testAlphabet("cCsSfFhHuUiItT01", t)
+}
+
+func TestShouldWorkWithHalfSeparators(t *testing.T) {
+	testAlphabet("abdegjklCFHISTUc", t)
+}
+
+func TestShouldWorkWithTwoSeparators(t *testing.T) {
+	testAlphabet("abdegjklmnopqrSF", t)
+}
+
+func TestShouldWorkWithNoSeparators(t *testing.T) {
+	testAlphabet("abdegjklmnopqrvwxyzABDEGJKLMNOPQRVWXYZ1234567890", t)
+}
+
+func TestShouldWorkWithSuperlong(t *testing.T) {
+	testAlphabet("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", t)
+}
+
+func TestShouldWorkWithWeird(t *testing.T) {
+	testAlphabet("`~!@#$%^&*()-_=+\\|'\";:/?.>,<{[}]", t)
+}

--- a/hashids_min_length_test.go
+++ b/hashids_min_length_test.go
@@ -1,0 +1,47 @@
+package hashids
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testMinLength(minLength int, t *testing.T) {
+	numbers := []int{1, 2, 3}
+	hdata := NewData()
+	hdata.MinLength = minLength
+	h := NewWithData(hdata)
+	e, err := h.Encode(numbers)
+	decodedNumbers := h.Decode(e)
+
+	if err != nil {
+		t.Errorf("Expected no error but got `%s`", err)
+	}
+
+	if len(e) < minLength {
+		t.Errorf("Expected hash length to be at least `%b`, was `%b`", minLength, len(e))
+	}
+
+	if !reflect.DeepEqual(decodedNumbers, numbers) {
+		t.Errorf("Decoded numbers `%b` did not match with original `%b`", decodedNumbers, numbers)
+	}
+}
+
+func TestShouldWorkWhen0(t *testing.T) {
+	testMinLength(0, t)
+}
+
+func TestShouldWorkWhen1(t *testing.T) {
+	testMinLength(1, t)
+}
+
+func TestShouldWorkWhen10(t *testing.T) {
+	testMinLength(10, t)
+}
+
+func TestShouldWorkWhen999(t *testing.T) {
+	testMinLength(999, t)
+}
+
+func TestShouldWorkWhen1000(t *testing.T) {
+	testMinLength(1000, t)
+}

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -176,3 +176,16 @@ func TestDecodeWithError(t *testing.T) {
 		t.Error("DecodeWithError should have returned error")
 	}
 }
+
+// tests issue #28
+func TestDecodeWithError2(t *testing.T) {
+	hid := New()
+	dec, err := hid.DecodeWithError("")
+
+	if dec != nil {
+		t.Errorf("Expected no slice (nil) but got `%b`", dec)
+	}
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+}


### PR DESCRIPTION
Adds `bad-input` and `min-length` tests from https://github.com/ivanakimov/hashids.js/tree/master/tests. `bad-input` revealed bug #30.