### PR TITLE
Reduce allocations to improve performance

### DIFF
--- a/hashids.go
+++ b/hashids.go
@@ -315,9 +315,7 @@ func splitRunes(input, seps []rune) [][]rune {
 	inputLeft := input[:]
 	for _, splitIndex := range splitIndices {
 		splitIndex -= len(input) - len(inputLeft)
-		subInput := make([]rune, splitIndex)
-		copy(subInput, inputLeft[:splitIndex])
-		result = append(result, subInput)
+		result = append(result, inputLeft[:splitIndex])
 		inputLeft = inputLeft[splitIndex+1:]
 	}
 	result = append(result, inputLeft)

--- a/hashids.go
+++ b/hashids.go
@@ -277,8 +277,12 @@ func (h *HashID) DecodeInt64WithError(hash string) ([]int64, error) {
 		hashBreakdown = hashBreakdown[1:]
 		hashes = splitRunes(hashBreakdown, h.seps)
 		alphabet := duplicateRuneSlice(h.alphabet)
+		buffer := make([]rune, len(alphabet)+len(h.salt)+1)
 		for _, subHash := range hashes {
-			buffer := append([]rune{lottery}, append(h.salt, alphabet...)...)
+			buffer = buffer[:1]
+			buffer[0] = lottery
+			buffer = append(buffer, h.salt...)
+			buffer = append(buffer, alphabet...)
 			consistentShuffleInPlace(alphabet, buffer[:len(alphabet)])
 			number, err := unhash(subHash, alphabet)
 			if err != nil {

--- a/hashids.go
+++ b/hashids.go
@@ -269,7 +269,7 @@ func (h *HashID) DecodeInt64WithError(hash string) ([]int64, error) {
 		hashIndex = 1
 	}
 
-	result := make([]int64, 0)
+	result := make([]int64, 0, 10)
 
 	hashBreakdown := hashes[hashIndex]
 	if len(hashBreakdown) > 0 {

--- a/hashids.go
+++ b/hashids.go
@@ -327,11 +327,11 @@ func hash(input int64, maxRuneLength int, alphabet []rune) []rune {
 			break
 		}
 	}
-	reversed := make([]rune, len(result))
-	for i, r := range result {
-		reversed[len(result)-i-1] = r
+	for i := len(result)/2 - 1; i >= 0; i-- {
+		opp := len(result) - 1 - i
+		result[i], result[opp] = result[opp], result[i]
 	}
-	return reversed
+	return result
 }
 
 func unhash(input, alphabet []rune) (int64, error) {

--- a/hashids.go
+++ b/hashids.go
@@ -186,7 +186,8 @@ func (h *HashID) EncodeInt64(numbers []int64) (string, error) {
 	for i, n := range numbers {
 		buffer = buffer[:1]
 		buffer[0] = lottery
-		buffer := append(buffer, append(h.salt, alphabet...)...)
+		buffer = append(buffer, h.salt...)
+		buffer = append(buffer, alphabet...)
 		consistentShuffleInPlace(alphabet, buffer[:len(alphabet)])
 		hashBuf = hash(n, alphabet, hashBuf)
 		result = append(result, hashBuf...)

--- a/hashids.go
+++ b/hashids.go
@@ -285,7 +285,8 @@ func (h *HashID) DecodeInt64WithError(hash string) ([]int64, error) {
 
 	sanityCheck, _ := h.EncodeInt64(result)
 	if sanityCheck != hash {
-		return result, errors.New("mismatch between encode and decode")
+		return result, fmt.Errorf("mismatch between encode and decode: %s start %s"+
+			" re-encoded. result: %v", hash, sanityCheck, result)
 	}
 
 	return result, nil

--- a/hashids.go
+++ b/hashids.go
@@ -79,8 +79,7 @@ func NewWithData(data *HashIDData) (*HashID, error) {
 	alphabet := []rune(data.Alphabet)
 	salt := []rune(data.Salt)
 
-	seps := make([]rune, len(sepsOriginal))
-	copy(seps, sepsOriginal)
+	seps := duplicateRuneSlice(sepsOriginal)
 
 	// seps should contain only characters present in alphabet; alphabet should not contains seps
 	for i := 0; i < len(seps); i++ {
@@ -165,8 +164,7 @@ func (h *HashID) EncodeInt64(numbers []int64) (string, error) {
 		}
 	}
 
-	alphabet := make([]rune, len(h.alphabet))
-	copy(alphabet, h.alphabet)
+	alphabet := duplicateRuneSlice(h.alphabet)
 
 	numbersHash := int64(0)
 	for i, n := range numbers {
@@ -358,8 +356,7 @@ func consistentShuffle(alphabet, salt []rune) []rune {
 		return alphabet
 	}
 
-	result := make([]rune, len(alphabet))
-	copy(result, alphabet)
+	result := duplicateRuneSlice(alphabet)
 	for i, v, p := len(result)-1, 0, 0; i > 0; i-- {
 		p += int(salt[v])
 		j := (int(salt[v]) + v + p) % i
@@ -367,5 +364,11 @@ func consistentShuffle(alphabet, salt []rune) []rune {
 		v = (v + 1) % len(salt)
 	}
 
+	return result
+}
+
+func duplicateRuneSlice(data []rune) []rune {
+	result := make([]rune, len(data))
+	copy(result, data)
 	return result
 }

--- a/hashids.go
+++ b/hashids.go
@@ -181,9 +181,12 @@ func (h *HashID) EncodeInt64(numbers []int64) (string, error) {
 	lottery := alphabet[numbersHash%int64(len(alphabet))]
 	result = append(result, lottery)
 	hashBuf := make([]rune, maxRuneLength)
+	buffer := make([]rune, len(alphabet)+len(h.salt)+1)
 
 	for i, n := range numbers {
-		buffer := append([]rune{lottery}, append(h.salt, alphabet...)...)
+		buffer = buffer[:1]
+		buffer[0] = lottery
+		buffer := append(buffer, append(h.salt, alphabet...)...)
 		consistentShuffleInPlace(alphabet, buffer[:len(alphabet)])
 		hashBuf = hash(n, alphabet, hashBuf)
 		result = append(result, hashBuf...)

--- a/hashids.go
+++ b/hashids.go
@@ -171,7 +171,6 @@ func (h *HashID) EncodeInt64(numbers []int64) (string, error) {
 		numbersHash += (n % int64(i+100))
 	}
 
-	// TODO(cmaloney): Include seps
 	maxRuneLength := h.maxLengthPerNumber * len(numbers)
 	if maxRuneLength < h.minLength {
 		maxRuneLength = h.minLength

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -170,7 +170,7 @@ func TestDecodeWithWrongSalt(t *testing.T) {
 
 	t.Logf("%v -> %v -> %v", numbers, hash, dec)
 
-	expected := "mismatch between encode and decode"
+	expected := "mismatch between encode and decode: ePaTMalsPMPlhxMl start MEhloASEPosaE re-encoded. result: [7 199 245 19]"
 	if err == nil || err.Error() != expected {
 		t.Errorf("Expected error `%s` but got `%s`", expected, err)
 	}

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -319,12 +319,13 @@ func TestAllocationsDecodeTypical(t *testing.T) {
 	checkAllocationsDecode(t, hid, singleNumber, 11)
 
 	// Same length, same number of allocations
-	checkAllocationsDecode(t, hid, maxNumbers, 17)
-	checkAllocationsDecode(t, hid, minNumbers, 17)
-	checkAllocationsDecode(t, hid, mixNubers, 17)
+	checkAllocationsDecode(t, hid, maxNumbers, 14)
+	checkAllocationsDecode(t, hid, minNumbers, 14)
+	checkAllocationsDecode(t, hid, mixNubers, 14)
 
-	// Greater length, same number of allocation
-	checkAllocationsDecode(t, hid, append(maxNumbers, maxNumbers...), 22)
-	checkAllocationsDecode(t, hid, append(minNumbers, minNumbers...), 22)
-	checkAllocationsDecode(t, hid, append(mixNubers, mixNubers...), 22)
+	// Greater length, same number of allocation per case. Length is long enough
+	// to not fit inisde the pre-allocated result buffer hence one extra alloc
+	checkAllocationsDecode(t, hid, append(maxNumbers, maxNumbers...), 15)
+	checkAllocationsDecode(t, hid, append(minNumbers, minNumbers...), 15)
+	checkAllocationsDecode(t, hid, append(mixNubers, mixNubers...), 15)
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -175,3 +175,21 @@ func TestDecodeWithWrongSalt(t *testing.T) {
 		t.Errorf("Expected error `%s` but got `%s`", expected, err)
 	}
 }
+
+func TestAllocationsPerEncode(t *testing.T) {
+	hdata := NewData()
+	hdata.Salt = "temp"
+	hdata.MinLength = 0
+	hid, _ := NewWithData(hdata)
+
+	numbers := []int64{math.MaxInt64, 0, 1024, math.MaxInt64 / 2}
+	allocsPerRun := testing.AllocsPerRun(100, func() {
+		_, err := hid.EncodeInt64(numbers)
+		if err != nil {
+			t.Errorf("Unexpected error encoding test data: %s, %v", err, numbers)
+		}
+	})
+	if allocsPerRun != 31 {
+		t.Errorf("Expected 31 allocations, got %v ", allocsPerRun)
+	}
+}

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -189,7 +189,7 @@ func TestAllocationsPerEncode(t *testing.T) {
 			t.Errorf("Unexpected error encoding test data: %s, %v", err, numbers)
 		}
 	})
-	if allocsPerRun != 15 {
-		t.Errorf("Expected 15 allocations, got %v ", allocsPerRun)
+	if allocsPerRun != 12 {
+		t.Errorf("Expected 12 allocations, got %v ", allocsPerRun)
 	}
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -204,13 +204,13 @@ func TestAllocationsPerEncodeTypical(t *testing.T) {
 
 	checkAllocations(t, hid, singleNumber, 6)
 
-	// Same length, same number of allocatoins
-	checkAllocations(t, hid, maxNumbers, 12)
-	checkAllocations(t, hid, minNumbers, 12)
-	checkAllocations(t, hid, mixNubers, 12)
+	// Same length, same number of allocations
+	checkAllocations(t, hid, maxNumbers, 9)
+	checkAllocations(t, hid, minNumbers, 9)
+	checkAllocations(t, hid, mixNubers, 9)
 
 	// Greater length, same number of allocation
-	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 20)
-	checkAllocations(t, hid, append(minNumbers, minNumbers...), 20)
-	checkAllocations(t, hid, append(mixNubers, mixNubers...), 20)
+	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 13)
+	checkAllocations(t, hid, append(minNumbers, minNumbers...), 13)
+	checkAllocations(t, hid, append(mixNubers, mixNubers...), 13)
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -319,12 +319,12 @@ func TestAllocationsDecodeTypical(t *testing.T) {
 	checkAllocationsDecode(t, hid, singleNumber, 11)
 
 	// Same length, same number of allocations
-	checkAllocationsDecode(t, hid, maxNumbers, 19)
-	checkAllocationsDecode(t, hid, minNumbers, 19)
-	checkAllocationsDecode(t, hid, mixNubers, 19)
+	checkAllocationsDecode(t, hid, maxNumbers, 17)
+	checkAllocationsDecode(t, hid, minNumbers, 17)
+	checkAllocationsDecode(t, hid, mixNubers, 17)
 
 	// Greater length, same number of allocation
-	checkAllocationsDecode(t, hid, append(maxNumbers, maxNumbers...), 25)
-	checkAllocationsDecode(t, hid, append(minNumbers, minNumbers...), 25)
-	checkAllocationsDecode(t, hid, append(mixNubers, mixNubers...), 25)
+	checkAllocationsDecode(t, hid, append(maxNumbers, maxNumbers...), 22)
+	checkAllocationsDecode(t, hid, append(minNumbers, minNumbers...), 22)
+	checkAllocationsDecode(t, hid, append(mixNubers, mixNubers...), 22)
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -189,7 +189,7 @@ func TestAllocationsPerEncode(t *testing.T) {
 			t.Errorf("Unexpected error encoding test data: %s, %v", err, numbers)
 		}
 	})
-	if allocsPerRun != 23 {
-		t.Errorf("Expected 23 allocations, got %v ", allocsPerRun)
+	if allocsPerRun != 19 {
+		t.Errorf("Expected 19 allocations, got %v ", allocsPerRun)
 	}
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -316,15 +316,15 @@ func TestAllocationsDecodeTypical(t *testing.T) {
 	minNumbers := []int64{0, 0, 0, 0}
 	mixNubers := []int64{math.MaxInt64, 0, 1024, math.MaxInt64 / 2}
 
-	checkAllocationsDecode(t, hid, singleNumber, 12)
+	checkAllocationsDecode(t, hid, singleNumber, 11)
 
 	// Same length, same number of allocations
-	checkAllocationsDecode(t, hid, maxNumbers, 26)
-	checkAllocationsDecode(t, hid, minNumbers, 26)
-	checkAllocationsDecode(t, hid, mixNubers, 26)
+	checkAllocationsDecode(t, hid, maxNumbers, 19)
+	checkAllocationsDecode(t, hid, minNumbers, 19)
+	checkAllocationsDecode(t, hid, mixNubers, 19)
 
 	// Greater length, same number of allocation
-	checkAllocationsDecode(t, hid, append(maxNumbers, maxNumbers...), 40)
-	checkAllocationsDecode(t, hid, append(minNumbers, minNumbers...), 40)
-	checkAllocationsDecode(t, hid, append(mixNubers, mixNubers...), 40)
+	checkAllocationsDecode(t, hid, append(maxNumbers, maxNumbers...), 25)
+	checkAllocationsDecode(t, hid, append(minNumbers, minNumbers...), 25)
+	checkAllocationsDecode(t, hid, append(mixNubers, mixNubers...), 25)
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -202,15 +202,15 @@ func TestAllocationsPerEncodeTypical(t *testing.T) {
 	minNumbers := []int64{0, 0, 0, 0}
 	mixNubers := []int64{math.MaxInt64, 0, 1024, math.MaxInt64 / 2}
 
-	checkAllocations(t, hid, singleNumber, 6)
+	checkAllocations(t, hid, singleNumber, 5)
 
 	// Same length, same number of allocations
-	checkAllocations(t, hid, maxNumbers, 9)
-	checkAllocations(t, hid, minNumbers, 9)
-	checkAllocations(t, hid, mixNubers, 9)
+	checkAllocations(t, hid, maxNumbers, 5)
+	checkAllocations(t, hid, minNumbers, 5)
+	checkAllocations(t, hid, mixNubers, 5)
 
 	// Greater length, same number of allocation
-	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 13)
-	checkAllocations(t, hid, append(minNumbers, minNumbers...), 13)
-	checkAllocations(t, hid, append(mixNubers, mixNubers...), 13)
+	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 5)
+	checkAllocations(t, hid, append(minNumbers, minNumbers...), 5)
+	checkAllocations(t, hid, append(mixNubers, mixNubers...), 5)
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -189,7 +189,7 @@ func TestAllocationsPerEncode(t *testing.T) {
 			t.Errorf("Unexpected error encoding test data: %s, %v", err, numbers)
 		}
 	})
-	if allocsPerRun != 19 {
-		t.Errorf("Expected 19 allocations, got %v ", allocsPerRun)
+	if allocsPerRun != 15 {
+		t.Errorf("Expected 15 allocations, got %v ", allocsPerRun)
 	}
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -189,8 +189,6 @@ func checkAllocations(t *testing.T, hid *HashID, values []int64, expectedAllocat
 }
 
 func TestAllocationsPerEncodeTypical(t *testing.T) {
-	// TODO(cmaloney): Test MinLength bits work as expected
-	// TODO(cmaloney): nil salt works as expected
 	hdata := NewData()
 	hdata.Salt = "temp"
 	hdata.MinLength = 0
@@ -213,4 +211,79 @@ func TestAllocationsPerEncodeTypical(t *testing.T) {
 	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 5)
 	checkAllocations(t, hid, append(minNumbers, minNumbers...), 5)
 	checkAllocations(t, hid, append(mixNubers, mixNubers...), 5)
+}
+
+func TestAllocationsPerEncodeNoSalt(t *testing.T) {
+	hdata := NewData()
+	hdata.Salt = ""
+	hdata.MinLength = 0
+	hid, _ := NewWithData(hdata)
+
+	singleNumber := []int64{42}
+
+	maxNumbers := []int64{math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64}
+	minNumbers := []int64{0, 0, 0, 0}
+	mixNubers := []int64{math.MaxInt64, 0, 1024, math.MaxInt64 / 2}
+
+	checkAllocations(t, hid, singleNumber, 5)
+
+	// Same length, same number of allocations
+	checkAllocations(t, hid, maxNumbers, 5)
+	checkAllocations(t, hid, minNumbers, 5)
+	checkAllocations(t, hid, mixNubers, 5)
+
+	// Greater length, same number of allocation
+	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 5)
+	checkAllocations(t, hid, append(minNumbers, minNumbers...), 5)
+	checkAllocations(t, hid, append(mixNubers, mixNubers...), 5)
+}
+
+func TestAllocationsPerEncodeMinLength(t *testing.T) {
+	hdata := NewData()
+	hdata.Salt = "temp"
+	hdata.MinLength = 10
+	hid, _ := NewWithData(hdata)
+
+	singleNumber := []int64{42}
+
+	maxNumbers := []int64{math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64}
+	minNumbers := []int64{0, 0, 0, 0}
+	mixNubers := []int64{math.MaxInt64, 0, 1024, math.MaxInt64 / 2}
+
+	checkAllocations(t, hid, singleNumber, 9)
+
+	// Same length, same number of allocations
+	checkAllocations(t, hid, maxNumbers, 5)
+	checkAllocations(t, hid, minNumbers, 6)
+	checkAllocations(t, hid, mixNubers, 5)
+
+	// Greater length, same number of allocation
+	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 5)
+	checkAllocations(t, hid, append(minNumbers, minNumbers...), 5)
+	checkAllocations(t, hid, append(mixNubers, mixNubers...), 5)
+}
+
+func TestAllocationsPerEncodeMinLengthHigh(t *testing.T) {
+	hdata := NewData()
+	hdata.Salt = "temp"
+	hdata.MinLength = 100
+	hid, _ := NewWithData(hdata)
+
+	singleNumber := []int64{42}
+
+	maxNumbers := []int64{math.MaxInt64, math.MaxInt64, math.MaxInt64, math.MaxInt64}
+	minNumbers := []int64{0, 0, 0, 0}
+	mixNubers := []int64{math.MaxInt64, 0, 1024, math.MaxInt64 / 2}
+
+	checkAllocations(t, hid, singleNumber, 15)
+
+	// Same length, same number of allocations
+	checkAllocations(t, hid, maxNumbers, 12)
+	checkAllocations(t, hid, minNumbers, 15)
+	checkAllocations(t, hid, mixNubers, 12)
+
+	// Greater length, same number of allocation
+	checkAllocations(t, hid, append(maxNumbers, maxNumbers...), 5)
+	checkAllocations(t, hid, append(minNumbers, minNumbers...), 12)
+	checkAllocations(t, hid, append(mixNubers, mixNubers...), 9)
 }

--- a/hashids_test.go
+++ b/hashids_test.go
@@ -189,7 +189,7 @@ func TestAllocationsPerEncode(t *testing.T) {
 			t.Errorf("Unexpected error encoding test data: %s, %v", err, numbers)
 		}
 	})
-	if allocsPerRun != 31 {
-		t.Errorf("Expected 31 allocations, got %v ", allocsPerRun)
+	if allocsPerRun != 23 {
+		t.Errorf("Expected 23 allocations, got %v ", allocsPerRun)
 	}
 }


### PR DESCRIPTION
hashids is in the middle of a fairly performance sensitive bit of code where I work (Returning thousands of search results, each result id gets encoded). The allocations which happen end up taking a significant amount of the time, so this PR works to reduce the number of allocations per execution from 31 + varying based on the input data to 5 always, while trying to keep the code reasonable to read / work through. The company's code using this doesn't use `MinLength`, so that I haven't spent a lot of time optimizing, and has more allocations which could probably be removed (Although less than it used to). There is a test added which should make it easier for someone to improve if they want down the line, as well as make sure it doesn't regress.

Overall:
 - EncodeInt64 allocations reduced from 31 to 5
 - DecodeInt64WithError allocations reduced from 21 to 11
when there is a salt and MinLength isn't specified for single-int64 encodings
