### PR TITLE
Fix hashids.NewWithData error handling

### DIFF
--- a/cmd/hashid/main.go
+++ b/cmd/hashid/main.go
@@ -29,7 +29,10 @@ func main() {
 	flag.StringVar(&separator, `sep`, ",", `separator for integers`)
 	flag.Parse()
 
-	codec := hashids.NewWithData(&params)
+	codec, err := hashids.NewWithData(&params)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+	}
 
 	args := os.Args[len(os.Args)-flag.NArg():]
 	if decode {


### PR DESCRIPTION
- this causes compile failure
	* assignment count mismatch (1 vs 2) (gotype)