### PR TITLE
cmd/hashid: fix tool after API breakage in go-hashids

### DIFF
--- a/cmd/hashid/main.go
+++ b/cmd/hashid/main.go
@@ -29,7 +29,11 @@ func main() {
 	flag.StringVar(&separator, `sep`, ",", `separator for integers`)
 	flag.Parse()
 
-	codec := hashids.NewWithData(&params)
+	codec, err := hashids.NewWithData(&params)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	args := os.Args[len(os.Args)-flag.NArg():]
 	if decode {


### PR DESCRIPTION
go-hashids broke API in 2aa1a76a4e7c76dbe7d39f40661ab0261d70153a